### PR TITLE
Eda cop

### DIFF
--- a/Avro/avro_files/utils/avroEDAUtils.py
+++ b/Avro/avro_files/utils/avroEDAUtils.py
@@ -16,6 +16,12 @@ def getDefaultEventValueSchema(schema_files_location):
   default_event_value_schema = LoadAvsc(schema_files_location + "/default_value.avsc", known_schemas)
   return default_event_value_schema
 
+def getDefaultEventValueSchemaConsumer(schema_files_location):
+  # Get the default event value data schema
+  known_schemas = avro.schema.Names()
+  default_event_value_schema = LoadAvsc(schema_files_location + "/default_value.avsc", known_schemas)
+  return default_event_value_schema
+
 def getDefaultEventKeySchema(schema_files_location):
   # Get the default event key data schema
   known_schemas = avro.schema.Names()

--- a/Avro/kafka/Confluent/Avro/new/KcAvroConsumer.py
+++ b/Avro/kafka/Confluent/Avro/new/KcAvroConsumer.py
@@ -18,7 +18,9 @@ class KafkaAvroConsumer:
         # Key Deserializer
         self.key_deserializer = StringDeserializer('utf_8')
         # Value Deserializer
-        # Presenting the schema to the Avro Deserializer is needed at the moment. In the future it might change
+        # Presenting the schema to the Avro Deserializer is needed at the moment. In the future it might change.
+        # Presenting the schema to the Avro Deserializer allows the consumer to get a schema version fixed for consuming messages as opposed
+        # to using the schema the message was serialized with (as the message travels with the schema id).
         # https://github.com/confluentinc/confluent-kafka-python/issues/834
         self.value_deserializer = AvroDeserializer(value_schema,self.schema_registry_client)
 

--- a/Avro/src/Confluent/Avro/new/ConsumeAvroMessage.py
+++ b/Avro/src/Confluent/Avro/new/ConsumeAvroMessage.py
@@ -1,4 +1,5 @@
-import os,sys,argparse
+import os,sys,argparse,time
+from re import S
 from kafka.Confluent.Avro.new.KcAvroConsumer import KafkaAvroConsumer
 from avro_files.utils.avroEDAUtils import *
 
@@ -9,13 +10,19 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     # Get the avro schemas for the message's value. We are not sending the key Avro serialized but it can be if needed.
-    # Presenting the schemas to the Avro Deserializer is needed. In the future it might change
+    # Presenting the schemas to the Avro Deserializer is needed. In the future it might change.
+    # Presenting the schema to the Avro Deserializer allows the consumer to get a schema version fixed for consuming messages as opposed
+    # to using the schema the message was serialized with (as the message travels with the schema id).
     # https://github.com/confluentinc/confluent-kafka-python/issues/834
-    event_value_schema = getDefaultEventValueSchema(os.getcwd().split("/src")[0] + "/avro_files")
+    event_value_schema = getDefaultEventValueSchemaConsumer(os.getcwd().split("/src")[0] + "/avro_files")
 
     # Create the Kafka Avro consumer
     kafka_avro_consumer = KafkaAvroConsumer(json.dumps(event_value_schema.to_json()),args.topic, autocommit = False)
-    # Consume next Avro event
-    event = kafka_avro_consumer.pollNextEvent()
+    
+    while True:
+        # Consume next Avro event
+        event = kafka_avro_consumer.pollNextEvent()
+        time.sleep(3)
+
     # Close the Avro consumer
     kafka_avro_consumer.close()

--- a/Avro/src/Confluent/Avro/new/ProduceAvroMessage.py
+++ b/Avro/src/Confluent/Avro/new/ProduceAvroMessage.py
@@ -24,7 +24,7 @@ if __name__ == '__main__':
     print("[MAIN] ----------------------------------------")
 
     # Create the Kafka Avro Producer
-    kafka_avro_producer = KafkaAvroProducer(json.dumps(event_value_schema.to_json()))
+    kafka_avro_producer = KafkaAvroProducer(json.dumps(event_value_schema.to_json()),args.topic)
 
     # Publish the event
     kafka_avro_producer.publishEvent(event_key, event_value, args.topic)


### PR DESCRIPTION
For the consumer
---

- Develop the ability to load an independent schema for the consumer in case you might want to have your consumer use a different version of the schema for consuming messages.
This aligns with the new AvroDeserializer confluent API that, for now, requires the schema at deserialization time for this very same reason. If you dont provide a schema for deserializing, the deserializer would have no other option than to use the schema indicated along with the message based on the schema-id that travels along.
Being able to use a different version of the schema for deserializing helps consuming messages in the exact shape and form your consumer expects these without needing for extra parsing or process after consumption.
- Also implemented an infinite consume loop so that the consumer consumes all messages and not only the event at offset 0 as it was the case. Now, the demos should have the consumer always running and then use the producer for demonstrations several use cases. This will be demoed in next week EDA CoP.

For the producer
---

- Worked around an actual issue in the producer that might be sth a new version of the Apicurio registry have introduced whereby you now need to explicitly tell whether or not you want your producer to auto register schemas or not (I dont think this is sth that ES has enforced even though it might make sesne) The fix is on `Avro/kafka/Confluent/Avro/new/KcAvroProducer.py` in line `34` and consist of explicitly saying I dont want my producer to auto register schemas.
- In relation with the above, there are a couple of threads open in with the ES team as the producer is not able to auto register schemas. See [here](https://ibm-cloud.slack.com/archives/CB777ACRM/p1645453484016569) and [here](https://ibm-cloud.slack.com/archives/CB777ACRM/p1645630807109779). It seems it has to do with ACLs.
- Enhanced the `KcAvroProducer` to print out way more information about the schema being used for education purposes. An example is:
```
[MAIN] -------- Event to be published: --------
[MAIN] Key: A key
[MAIN] Value:{"message": "This is an avro test message using the new APIs"}
[MAIN] ----------------------------------------
[KafkaAvroProducer] - Schema Information:
[KafkaAvroProducer] - ===================
[KafkaAvroProducer] - Version IDs for the Schema:  test-value [1, 2, 3]
[KafkaAvroProducer] - Schema: {   
    "namespace": "ibm.eda.default",
    "doc": "Default Message's value Avro data schema",
    "type":"record",
    "name":"defaultValue",
    "fields":[
            {
                "name": "message",
                "type":"string",
                "doc": "Any string"
            },
            {
                "name": "anotherAttribute",
                "type":"string",
                "doc": "Any string",
                "default" : "This is the default string"
            },
            {
                "name": "anotherAttributeAgain",
                "type":"string",
                "doc": "Any string",
                "default" : "This is the default string again"
            }
     ]
}
[KafkaAvroProducer] - Schema type: AVRO
[KafkaAvroProducer] - Schema ID:  262144
[KafkaAvroProducer] - Schema subject: test-value
[KafkaAvroProducer] - Schema version:  3
[KafkaAvroProducer] - This is the configuration for the producer:
[KafkaAvroProducer] - -------------------------------------------
[KafkaAvroProducer] - Bootstrap Server:      es-eda-dev-kafka-bootstrap-eda.itzroks-xxxxx.eu-gb.containers.appdomain.cloud:443
[KafkaAvroProducer] - Schema Registry url:   es-eda-dev-ibm-es-ac-reg-external-eda.itzroks-xxxxx.eu-gb.containers.appdomain.cloud
[KafkaAvroProducer] - Security Protocol:     SASL_SSL
[KafkaAvroProducer] - SASL Mechanism:        SCRAM-SHA-512
[KafkaAvroProducer] - SASL Username:         test-creds
[KafkaAvroProducer] - SASL Password:         V*****E
[KafkaAvroProducer] - SSL CA Location:       es-cert.pem
[KafkaAvroProducer] - -------------------------------------------
[KafkaAvroProducer] - Message delivered to test [0]
``` 